### PR TITLE
ci: publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Setup Node
+      - name: Setup Node (GitHub Packages)
         uses: actions/setup-node@v5
         with:
           node-version: 22
@@ -89,7 +89,7 @@ jobs:
         if: steps.detect.outputs.release_type != 'none'
         run: npm run release:${{ steps.detect.outputs.release_type }}
 
-      - name: Publish and push release
+      - name: Publish to GitHub Packages
         if: steps.detect.outputs.release_type != 'none'
         env:
           NODE_AUTH_TOKEN: ${{ github.token }}
@@ -101,8 +101,26 @@ jobs:
           if [ "${GITHUB_REPOSITORY}" = "jhderojasUVa/gate-keeper" ]; then
             npm publish
           fi
+
+      - name: Setup Node (npm registry)
+        if: steps.detect.outputs.release_type != 'none'
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Publish to npm
+        if: steps.detect.outputs.release_type != 'none'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          npm publish --access public
           
-          # Configure git and push atomically with publish
+      - name: Push release commit and tags
+        if: steps.detect.outputs.release_type != 'none'
+        run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git push origin main --follow-tags

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
         "gate-keeper": "./src/server/index.mjs",
         "gate-keeper-init": "./src/init.mjs"
     },
-    "publishConfig": {
-        "registry": "https://npm.pkg.github.com/"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/jhderojasUVa/gate-keeper.git"


### PR DESCRIPTION
## Description

We need to publish to NPM too!

## Why Are You Changing This?

Currently we are only publishing to github, but NPM is also a must.

## What Have You Changed?

Pipeline updated

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass: `npm run test`
- [x] Linting passes: `npm run lint`

## Checklist

- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/) format for my commits
- [ ] I have updated the documentation (README.md, etc.) if needed
- [ ] I have added or updated tests for my changes
- [x] All tests pass (`npm run test`)
- [x] My code passes linting (`npm run lint`)
- [x] I have reviewed my own code
- [x] My branch is up to date with the main branch
